### PR TITLE
Update argus to 0.4.0

### DIFF
--- a/plugins/xcode/skills/argus/SKILL.md
+++ b/plugins/xcode/skills/argus/SKILL.md
@@ -10,7 +10,7 @@ Use argus to analyze Xcode builds instead of parsing raw xcodebuild output.
 ## Installation
 
 ```bash
-mise install github:tuist/argus
+mise install github:tuist/argus@0.4.0
 ```
 
 ## Running a Build


### PR DESCRIPTION
## Summary
- Pin argus version to 0.4.0 in the installation instructions

## Test plan
- [x] Verify `mise install github:tuist/argus@0.4.0` installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)